### PR TITLE
Adding instructions for running locally on Docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ docker run -p 3306:3306 --name sky-with-me \
 -d mysql:latest
 ```
 
-Given [to this thread](https://github.com/mysqljs/mysql/issues/2046) we need to do one more thing to allow to connect unsafely to MySQL locally (just for development purposes).  
+Assuming [to this thread](https://github.com/mysqljs/mysql/issues/2046) we need to do one more thing to allow to connect unsafely to MySQL locally (just for development purposes).  
 The following commands connect us to the Docker container with MySQL instance running:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -46,3 +46,41 @@ Search based on:
 Add an option to mark as favorite people you'd like to go ski/snowboard with.
 
 Would like to have something similar to [Coding Coach](https://mentors.codingcoach.io/)
+
+## Instructions for running locally
+
+### Database migrations
+
+The project relies on a running MySQL database.  
+Docker can be used to have a running instance on the local machine.
+Given that Docker is installed and running, the following command will download MySQL image and run it:
+
+```bash
+docker run -p 3306:3306 --name sky-with-me \
+-e MYSQL_ROOT_PASSWORD=password \
+-e MYSQL_DATABASE=skywithme \
+-d mysql:latest
+```
+
+Given [to this thread](https://github.com/mysqljs/mysql/issues/2046) we need to do one more thing to allow to connect unsafely to MySQL locally (just for development purposes).  
+The following commands connect us to the Docker container with MySQL instance running:
+
+```bash
+docker exec -it sky-with-me /bin/bash
+mysql -u root -p # it's "password" from MYSQL_ROOT_PASSWORD
+```
+
+```sql
+ALTER USER 'root' IDENTIFIED WITH mysql_native_password BY 'password';
+```
+
+After this changes you should be able to create a `.env` file with the following content:
+
+```
+DB_HOST=0.0.0.0
+DB_USER=root
+DB_PASS=password
+DB_NAME=skywithme
+```
+
+If everything was successful then the command `npm run migrate` should execute without errors.


### PR DESCRIPTION
I like to have MySQL running on Docker, so I don't have to install MySQL and remember if it's running on not.
I just close Docker when I am done.
What do you think about this added section to the README?
Let me know if you think that there are better options for having MySQL available.

Cheers.