### PR TITLE
updated addUser and login functions with new syntax

### DIFF
--- a/client/src/components/InputBox.js
+++ b/client/src/components/InputBox.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 function InputBox({ label, type, value, onChange, required }) {
-    console.log("req", required)
     return (
 
         <>

--- a/client/src/components/Login.js
+++ b/client/src/components/Login.js
@@ -23,27 +23,26 @@ function Login(props) {
     history.push("/");
   };
 
-  const attemptLogin = (e) => {
+
+  const loginData = {
+    email,
+    password
+  }
+
+  const attemptLogin = async (e) => {
     e.preventDefault()
-    axios("/users/login", {
-      method: "POST",
-      headers: { "Content-type": "application/json" },
-      data: {
-        email: email,
-        password: password,
-      },
-    })
-      .then((results) => {
-        localStorage.setItem("skiBuddyToken", results.data.token);
-        props.updateLoggedIn(true);
-        props.getName(results.data.name);
-        props.getUserId(results.data.id)
-      })
-      .catch((err) => {
-        if (err.response.status === 400) {
-          setShowAlert(true)
-        }
-      })
+    try {
+      const resp = await axios.post('/users/login', loginData);
+      localStorage.setItem("skiBuddyToken", resp.data.token);
+      props.updateLoggedIn(true);
+      props.getName(resp.data.name);
+      props.getUserId(resp.data.id)
+    }
+    catch (err) {
+      if (err.response.status === 400) {
+        setShowAlert(true)
+      }
+    }
   };
 
   return (

--- a/client/src/components/Register.js
+++ b/client/src/components/Register.js
@@ -64,34 +64,31 @@ function Register(props) {
     history.push("/");
   };
 
-  const addUser = () => {
-
-    axios("/users/register", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      data: {
-        first_name: firstName,
-        last_name: lastName,
-        email: email,
-        password: password,
-        sport: sport,
-        level: level,
-        resorts: resorts,
-        languages: languages,
-      },
-    })
-      .then((results) => {
-        localStorage.setItem("skiBuddyToken", results.data.token);
-        props.updateLoggedIn(true);
-        props.getName(results.data.name);
-        props.getUserId(results.data.id)
-        props.history.push("/");
-      })
-      .catch((err) => console.log(err));
+  const userData = {
+    first_name: firstName,
+    last_name: lastName,
+    email: email,
+    password: password,
+    sport: sport,
+    level: level,
+    resorts: resorts,
+    languages: languages,
   }
 
+  const addUser = async () => {
+    // e.preventDefault()
+    try {
+      const resp = await axios.post('/users/register', userData);
+      localStorage.setItem("skiBuddyToken", resp.data.token);
+      props.updateLoggedIn(true);
+      props.getName(resp.data.name);
+      props.getUserId(resp.data.id)
+      props.history.push("/");
+    }
+    catch (err) {
+      console.log(err)
+    }
+  };
 
   return (
     <>

--- a/client/src/components/SkierCard.js
+++ b/client/src/components/SkierCard.js
@@ -7,6 +7,7 @@ const SkierCardDiv = styled.div`
         padding : 30px 15px;
         border-radius: 10px;
         boxShadow: 0px 4px 8px 0px hsla(0, 0%, 0%, 0.2);
+      
     `
 const Title = styled.h1`
         color: #649CCC;

--- a/client/src/components/SkiersList.js
+++ b/client/src/components/SkiersList.js
@@ -2,7 +2,7 @@ import React from "react"
 import SkierCard from "./SkierCard"
 
 
-function SkiersList(props) {  
+function SkiersList(props) {
     return (
         <>
             {


### PR DESCRIPTION
Hi @mathieudutour,

I moved the axios post requests from the .then syntax to try-catch for both Login and Register components. I found that I no longer need to pass the header (headers: { "Content-type": "application/json" }) as it didn't work with it. Is this done correctly?

It worked but thought it's best to double check.

Thank you,
Stefi

#26 